### PR TITLE
Heroku orb: rename to not use reserved keyword, fixes bash if-then statement

### DIFF
--- a/src/heroku/orb.yml
+++ b/src/heroku/orb.yml
@@ -25,7 +25,7 @@ commands:
             else
               echo "Heroku is already installed. No operation was performed."
             fi
-  deploy_to_heroku_via_git:
+  deploy-via-git:
     parameters:
       app-name:
         description:
@@ -60,11 +60,11 @@ commands:
       - run:
           name: Deploy branch to Heroku via git push
           command: |
-            if [ "<< parameters.only-branch >>" == "" ] || [ "${CIRCLE_BRANCH}" == "<< parameters.only-branch >>" ]; then
+            if [[ "<< parameters.only-branch >>" == "" ]] || [[ "${CIRCLE_BRANCH}" == "<< parameters.only-branch >>" ]]; then
               git push https://heroku:<< parameters.api-key >>@git.heroku.com/<< parameters.app-name >>.git << parameters.branch >>
             fi
 jobs:
-  deploy_to_heroku_via_git:
+  deploy-via-git:
     parameters:
       app-name:
         description:

--- a/src/heroku/orb.yml
+++ b/src/heroku/orb.yml
@@ -25,7 +25,7 @@ commands:
             else
               echo "Heroku is already installed. No operation was performed."
             fi
-  deploy:
+  deploy_to_heroku_via_git:
     parameters:
       app-name:
         description:
@@ -60,11 +60,11 @@ commands:
       - run:
           name: Deploy branch to Heroku via git push
           command: |
-            if [ "<< paramaters.only-branch >>" == "" || "${CIRCLE_BRANCH}" == "<< paramaters.only-branch >>" ]; then
+            if [ "<< parameters.only-branch >>" == "" ] || [ "${CIRCLE_BRANCH}" == "<< parameters.only-branch >>" ]; then
               git push https://heroku:<< parameters.api-key >>@git.heroku.com/<< parameters.app-name >>.git << parameters.branch >>
             fi
 jobs:
-  deploy:
+  deploy_to_heroku_via_git:
     parameters:
       app-name:
         description:
@@ -96,6 +96,7 @@ jobs:
     executor: default
     steps:
       - install
+      - checkout
       - when:
           condition: << parameters.maintenance-mode >>
           steps:


### PR DESCRIPTION
Fixes two issues:
* Eliminates use of reserved work 'deploy' in commands and jobs within orb
* Fixes syntax and typo within if-then bash statement

Also, adds ability to deploy successfully if 'deploy_to_heroku_via_git' job is performed in a separate workflow step, instead of within a single build job.