### PR TITLE
create docker-publish orb

### DIFF
--- a/src/docker-publish/orb.yml
+++ b/src/docker-publish/orb.yml
@@ -53,6 +53,34 @@ examples:
                   registry: my.docker.registry
                   dockerfile: path/to/MyDockerFile
 
+  life_cycle_hooks:
+    description: |
+      Build and deploy a docker image with custom lifecycle hooks; before
+      checking out the code from the VCS repository, before building the 
+      docker image, and after building the docker image. 
+    usage:
+      version: 2.1
+
+      orbs:
+        docker-publish: circleci/docker-publish@1.0.0
+
+      workflows:
+        docker_with_lifecycle:
+          jobs:
+            - docker-publish/publish:
+                after_checkout:
+                  - run:
+                      name: Do this after checkout.
+                      command: echo "Did this after checkout"
+                before_build:
+                  - run:
+                      name: Do this before the build.
+                      command: echo "Did this before the build"
+                after_build:
+                  - run:
+                      name: Do this after the build.
+                      command: echo "Did this after the build"
+
 executors:
   docker:
     description: The docker container to use when running docker-publish builds
@@ -147,16 +175,40 @@ jobs:
         description: Name of registry to use. Defaults to docker.io.
         type: string
         default: docker.io
+      after_checkout:
+        description: Optional steps to run after checking out the code. 
+        type: steps
+        default: []
+      before_build:
+        description: Optional steps to run before building the docker image.
+        type: steps
+        default: []
+      after_build:
+        description: Optional steps to run after building the docker image.
+        type: steps
+        default: []
     steps:
       - checkout
+      - when:
+          name: Run after_checkout lifecycle hook steps.
+          condition: << parameters.after_checkout >>
+          steps: << parameters.after_checkout >>
       - setup_remote_docker
       - check:
           registry: << parameters.registry >>
+      - when:
+          name: Run before_build lifecycle hook steps.
+          condition: << parameters.before_build >>
+          steps: << parameters.before_build >>
       - build:
           dockerfile: << parameters.dockerfile >>
           image: << parameters.image >>
           tag: << parameters.tag >>
           registry: << parameters.registry >>
+      - when:
+          name: Run after_build lifecycle hook steps.
+          condition: << parameters.after_build >>
+          steps: << parameters.after_build >>
       - deploy:
           registry: << parameters.registry >>
           image: << parameters.image >>

--- a/src/docker-publish/orb.yml
+++ b/src/docker-publish/orb.yml
@@ -16,10 +16,10 @@ examples:
       orbs:
         docker-publish: circleci/docker-publish@1.0.0
 
-        workflows:
-          build_and_publish_docker_image:
-            jobs:
-              - docker-publish/publish
+      workflows:
+        build_and_publish_docker_image:
+          jobs:
+            - docker-publish/publish
   
   custom_name_and_tag:
     description: Build and Deploy docker image with a custom name and tag.
@@ -29,12 +29,12 @@ examples:
       orbs:
         docker-publish: circleci/docker-publish@1.0.0
 
-        workflows:
-          build_and_publish_docker_image:
-            jobs:
-              - docker-publish/publish:
-                  image: my/image
-                  tag: my_tag
+      workflows:
+        build_and_publish_docker_image:
+          jobs:
+            - docker-publish/publish:
+                image: my/image
+                tag: my_tag
 
   custom_name_and_tag:
     description: | 
@@ -46,12 +46,12 @@ examples:
       orbs:
         docker-publish: circleci/docker-publish@1.0.0
 
-        workflows:
-          build_and_publish_docker_image:
-            jobs:
-              - docker-publish/publish:
-                  registry: my.docker.registry
-                  dockerfile: path/to/MyDockerFile
+      workflows:
+        build_and_publish_docker_image:
+          jobs:
+            - docker-publish/publish:
+                registry: my.docker.registry
+                dockerfile: path/to/MyDockerFile
 
   life_cycle_hooks:
     description: |

--- a/src/docker-publish/orb.yml
+++ b/src/docker-publish/orb.yml
@@ -1,14 +1,14 @@
 version: 2.1
-description: | 
-  The docker-publish orb encapsulates common tasks for building and publishing 
+description: |
+  The docker-publish orb encapsulates common tasks for building and publishing
   a docker image to a registry.
 
 examples:
   standard_build_and_push:
     description: |
-      A standard docker workflow, where you are building an image with a 
-      Dockerfile in the root of your repository, naming the image to be the 
-      same name as your repository, and then pushing to the default docker 
+      A standard docker workflow, where you are building an image with a
+      Dockerfile in the root of your repository, naming the image to be the
+      same name as your repository, and then pushing to the default docker
       registry (at docker.io).
     usage:
       version: 2.1
@@ -20,7 +20,7 @@ examples:
         build_and_publish_docker_image:
           jobs:
             - docker-publish/publish
-  
+
   custom_name_and_tag:
     description: Build and Deploy docker image with a custom name and tag.
     usage:
@@ -37,8 +37,8 @@ examples:
                 tag: my_tag
 
   custom_name_and_tag:
-    description: | 
-      Build and Deploy docker image with a non standard Dockerfile and to a 
+    description: |
+      Build and Deploy docker image with a non standard Dockerfile and to a
       custom registry.
     usage:
       version: 2.1
@@ -56,8 +56,8 @@ examples:
   life_cycle_hooks:
     description: |
       Build and deploy a docker image with custom lifecycle hooks; before
-      checking out the code from the VCS repository, before building the 
-      docker image, and after building the docker image. 
+      checking out the code from the VCS repository, before building the
+      docker image, and after building the docker image.
     usage:
       version: 2.1
 
@@ -176,7 +176,7 @@ jobs:
         type: string
         default: docker.io
       after_checkout:
-        description: Optional steps to run after checking out the code. 
+        description: Optional steps to run after checking out the code.
         type: steps
         default: []
       before_build:

--- a/src/docker-publish/orb.yml
+++ b/src/docker-publish/orb.yml
@@ -1,0 +1,152 @@
+version: 2.1
+description: "The docker-publish orb encapsulates common tasks for publishing a docker image to dockerhub."
+
+# Usage Examples
+# --
+#
+# If you have a standard docker workflow, where you are building an image with a Dockerfile in the root
+# of your repository, naming the image to be the same name as your repository, and then pushing to
+# the default docker registry (at hub.docker.com). Then you can perform these tasks without any additional
+# configuration with the following circle.yml config:
+#
+# version: 2.1
+# orbs:
+#   docker: circleci/docker@dev:volatile
+#
+# workflows:
+#   publish:
+#     jobs:
+#       - docker/publish
+#
+# --
+# You could use a different naming and tagging convention with a configuration like this:
+#
+# version: 2.1
+# orbs:
+#   docker: circleci/docker@dev:volatile
+#
+# workflows:
+#   publish:
+#     jobs:
+#       - docker/publish:
+#           image: my/image
+#           tag: mytag
+#
+# --
+# You could use a different Dockerfile and push to a different regsitry with a configuration like this:
+#
+# version: 2.1
+# orbs:
+#   docker: circleci/docker@dev:volatile
+#
+# workflows:
+#   publish:
+#     jobs:
+#       - docker/publish:
+#           registry: my.docker.registry
+#           dockerfile: path/to/MyDockerFile
+
+executors:
+  docker:
+    description: The docker container to use when running docker-publish builds
+    docker:
+      - image: circleci/python:3.6
+
+commands:
+  check:
+    description: |
+      Sanity check to make sure you can build a docker image.
+
+        * check that $DOCKER_LOGIN and $DOCKER_PASSWORD environment variables are set
+        * run docker login to ensure that you can push the built image
+
+      Parameters -
+        registry (optional); Name of alternate registry to use. Defaults to hub.docker.com.
+    parameters:
+      registry:
+        type: string
+    steps:
+      - run:
+          name: Check Environment Variables
+          command: |
+            if [[ -z "${DOCKER_LOGIN}" ]]; then
+              echo "DOCKER_LOGIN is not set, will not be able to push image."
+              exit 1
+            fi
+
+            if [[ -z "${DOCKER_PASSWORD}" ]]; then
+              echo "DOCKER_PASSWORD is not set, will not be able to push image."
+              exit 1
+            fi
+      - run:
+          name: Docker Login
+          command: docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD << parameters.registry >>
+  build:
+    description: |
+      Builds a docker image.
+
+      Parameters -
+        dockerfile (optional); Name of alternate dockerfile to use. Defaults to Dockerfile in working directly.
+        image (optional); Name of image to create. Defaults to a combination of $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME.
+        tag (optional); Name of alternate tag to use. Defaults to $CIRCLE_SHA1
+        registry (optional); Name of alternate registry to use. Defaults to hub.docker.com.
+    parameters:
+      dockerfile:
+        type: string
+      image:
+        type: string
+      tag:
+        type: string
+      registry:
+        type: string
+    steps:
+      - run:
+          name: Build Docker Image
+          command: docker build -f << parameters.dockerfile >> -t << parameters.registry >>/<< parameters.image >>:<< parameters.tag >> .
+  deploy:
+    description: |
+      Deploy Docker image to registry.
+
+      Parameters -
+        registry (optional); Name of alternate registry to use. Defaults to hub.docker.com.
+        image (optional); Name of image to create. Defaults to a combination of $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME.
+    parameters:
+      registry:
+        type: string
+      image:
+        type: string
+    steps:
+      - run:
+          name: Push Docker Image
+          command: docker push << parameters.registry >>/<< parameters.image >>
+
+jobs:
+  publish:
+    description: Check, Build, and Deploy a Docker Image.
+    executor: docker
+    parameters:
+      dockerfile:
+        type: string
+        default: Dockerfile
+      image:
+        type: string
+        default: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
+      tag:
+        type: string
+        default: $CIRCLE_SHA1
+      registry:
+        type: string
+        default: docker.io
+    steps:
+      - checkout
+      - setup_remote_docker
+      - check:
+          registry: << parameters.registry >>
+      - build:
+          dockerfile: << parameters.dockerfile >>
+          image: << parameters.image >>
+          tag: << parameters.tag >>
+          registry: << parameters.registry >>
+      - deploy:
+          registry: << parameters.registry >>
+          image: << parameters.image >>

--- a/src/docker-publish/orb.yml
+++ b/src/docker-publish/orb.yml
@@ -1,12 +1,12 @@
 version: 2.1
-description: "The docker-publish orb encapsulates common tasks for publishing a docker image to dockerhub."
+description: "The docker-publish orb encapsulates common tasks for building and publishing a docker image to a registry."
 
 # Usage Examples
 # --
 #
 # If you have a standard docker workflow, where you are building an image with a Dockerfile in the root
 # of your repository, naming the image to be the same name as your repository, and then pushing to
-# the default docker registry (at hub.docker.com). Then you can perform these tasks without any additional
+# the default docker registry (at docker.io). Then you can perform these tasks without any additional
 # configuration with the following circle.yml config:
 #
 # version: 2.1
@@ -61,7 +61,7 @@ commands:
         * run docker login to ensure that you can push the built image
 
       Parameters -
-        registry (optional); Name of alternate registry to use. Defaults to hub.docker.com.
+        registry (optional); Name of alternate registry to use. Defaults to docker.io.
     parameters:
       registry:
         type: string
@@ -89,7 +89,7 @@ commands:
         dockerfile (optional); Name of alternate dockerfile to use. Defaults to Dockerfile in working directly.
         image (optional); Name of image to create. Defaults to a combination of $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME.
         tag (optional); Name of alternate tag to use. Defaults to $CIRCLE_SHA1
-        registry (optional); Name of alternate registry to use. Defaults to hub.docker.com.
+        registry (optional); Name of alternate registry to use. Defaults to docker.io.
     parameters:
       dockerfile:
         type: string
@@ -108,7 +108,7 @@ commands:
       Deploy Docker image to registry.
 
       Parameters -
-        registry (optional); Name of alternate registry to use. Defaults to hub.docker.com.
+        registry (optional); Name of alternate registry to use. Defaults to docker.io.
         image (optional); Name of image to create. Defaults to a combination of $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME.
     parameters:
       registry:

--- a/src/docker-publish/orb.yml
+++ b/src/docker-publish/orb.yml
@@ -11,7 +11,7 @@ description: "The docker-publish orb encapsulates common tasks for building and 
 #
 # version: 2.1
 # orbs:
-#   docker: circleci/docker@dev:volatile
+#   docker: circleci/docker-publish@dev:volatile
 #
 # workflows:
 #   publish:
@@ -23,7 +23,7 @@ description: "The docker-publish orb encapsulates common tasks for building and 
 #
 # version: 2.1
 # orbs:
-#   docker: circleci/docker@dev:volatile
+#   docker: circleci/docker-publish@dev:volatile
 #
 # workflows:
 #   publish:
@@ -37,7 +37,7 @@ description: "The docker-publish orb encapsulates common tasks for building and 
 #
 # version: 2.1
 # orbs:
-#   docker: circleci/docker@dev:volatile
+#   docker: circleci/docker-publish@dev:volatile
 #
 # workflows:
 #   publish:

--- a/src/docker-publish/orb.yml
+++ b/src/docker-publish/orb.yml
@@ -1,50 +1,57 @@
 version: 2.1
-description: "The docker-publish orb encapsulates common tasks for building and publishing a docker image to a registry."
+description: | 
+  The docker-publish orb encapsulates common tasks for building and publishing 
+  a docker image to a registry.
 
-# Usage Examples
-# --
-#
-# If you have a standard docker workflow, where you are building an image with a Dockerfile in the root
-# of your repository, naming the image to be the same name as your repository, and then pushing to
-# the default docker registry (at docker.io). Then you can perform these tasks without any additional
-# configuration with the following circle.yml config:
-#
-# version: 2.1
-# orbs:
-#   docker: circleci/docker-publish@dev:volatile
-#
-# workflows:
-#   publish:
-#     jobs:
-#       - docker/publish
-#
-# --
-# You could use a different naming and tagging convention with a configuration like this:
-#
-# version: 2.1
-# orbs:
-#   docker: circleci/docker-publish@dev:volatile
-#
-# workflows:
-#   publish:
-#     jobs:
-#       - docker/publish:
-#           image: my/image
-#           tag: mytag
-#
-# --
-# You could use a different Dockerfile and push to a different regsitry with a configuration like this:
-#
-# version: 2.1
-# orbs:
-#   docker: circleci/docker-publish@dev:volatile
-#
-# workflows:
-#   publish:
-#     jobs:
-#       - docker/publish:
-#           registry: my.docker.registry
-#           dockerfile: path/to/MyDockerFile
+examples:
+  standard_build_and_push:
+    description: |
+      A standard docker workflow, where you are building an image with a 
+      Dockerfile in the root of your repository, naming the image to be the 
+      same name as your repository, and then pushing to the default docker 
+      registry (at docker.io).
+    usage:
+      version: 2.1
+
+      orbs:
+        docker-publish: circleci/docker-publish@1.0.0
+
+        workflows:
+          build_and_publish_docker_image:
+            jobs:
+              - docker-publish/publish
+  
+  custom_name_and_tag:
+    description: Build and Deploy docker image with a custom name and tag.
+    usage:
+      version: 2.1
+
+      orbs:
+        docker-publish: circleci/docker-publish@1.0.0
+
+        workflows:
+          build_and_publish_docker_image:
+            jobs:
+              - docker-publish/publish:
+                  image: my/image
+                  tag: my_tag
+
+  custom_name_and_tag:
+    description: | 
+      Build and Deploy docker image with a non standard Dockerfile and to a 
+      custom registry.
+    usage:
+      version: 2.1
+
+      orbs:
+        docker-publish: circleci/docker-publish@1.0.0
+
+        workflows:
+          build_and_publish_docker_image:
+            jobs:
+              - docker-publish/publish:
+                  registry: my.docker.registry
+                  dockerfile: path/to/MyDockerFile
 
 executors:
   docker:
@@ -59,12 +66,11 @@ commands:
 
         * check that $DOCKER_LOGIN and $DOCKER_PASSWORD environment variables are set
         * run docker login to ensure that you can push the built image
-
-      Parameters -
-        registry (optional); Name of alternate registry to use. Defaults to docker.io.
     parameters:
       registry:
+        description: Name of registry to use. Defaults to docker.io.
         type: string
+        default: docker.io
     steps:
       - run:
           name: Check Environment Variables
@@ -82,39 +88,39 @@ commands:
           name: Docker Login
           command: docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD << parameters.registry >>
   build:
-    description: |
-      Builds a docker image.
-
-      Parameters -
-        dockerfile (optional); Name of alternate dockerfile to use. Defaults to Dockerfile in working directly.
-        image (optional); Name of image to create. Defaults to a combination of $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME.
-        tag (optional); Name of alternate tag to use. Defaults to $CIRCLE_SHA1
-        registry (optional); Name of alternate registry to use. Defaults to docker.io.
+    description: Builds and Tags a Docker Image.
     parameters:
       dockerfile:
+        description: Name of dockerfile to use. Defaults to Dockerfile in working directory.
         type: string
+        default: Dockerfile
       image:
+        description: Name of image to create. Defaults to a combination of $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME.
         type: string
+        default: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
       tag:
+        description: Value for tag to use. Defaults to $CIRCLE_SHA1.
         type: string
+        default: $CIRCLE_SHA1
       registry:
+        description: Name of registry to use. Defaults to docker.io.
         type: string
+        default: docker.io
     steps:
       - run:
           name: Build Docker Image
           command: docker build -f << parameters.dockerfile >> -t << parameters.registry >>/<< parameters.image >>:<< parameters.tag >> .
   deploy:
-    description: |
-      Deploy Docker image to registry.
-
-      Parameters -
-        registry (optional); Name of alternate registry to use. Defaults to docker.io.
-        image (optional); Name of image to create. Defaults to a combination of $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME.
+    description: Deploy docker image to a registry.
     parameters:
       registry:
+        description: Name of registry to use. Defaults to docker.io.
         type: string
+        default: docker.io
       image:
+        description: Name of image to create. Defaults to a combination of $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME.
         type: string
+        default: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
     steps:
       - run:
           name: Push Docker Image
@@ -126,15 +132,19 @@ jobs:
     executor: docker
     parameters:
       dockerfile:
+        description: Name of dockerfile to use. Defaults to Dockerfile in working directory.
         type: string
         default: Dockerfile
       image:
+        description: Name of image to create. Defaults to a combination of $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME.
         type: string
         default: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
       tag:
+        description: Value for tag to use. Defaults to $CIRCLE_SHA1.
         type: string
         default: $CIRCLE_SHA1
       registry:
+        description: Name of registry to use. Defaults to docker.io.
         type: string
         default: docker.io
     steps:


### PR DESCRIPTION
This orb allows you to easily go through a docker build and publish workflow. 

With no arguments, it will find the local Dockerfile, build the image, tag it with `$DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1` and push it to the default registry at `docker.io`. 

You can customize all of these components: 
* Dockerfile 
* Image Naming Convention
* Image Tag Convention
* Registry

You can see all of this in action in the following public workflow build: https://circleci.com/workflow-run/06540309-cd71-482c-8f58-9f29c9efd122