### PR TITLE
Fix the `notify_deploy` job in the rollbar orb

### DIFF
--- a/src/rollbar/orb.yml
+++ b/src/rollbar/orb.yml
@@ -32,7 +32,7 @@ jobs:
       A Rollbar access token is required to be set in the
       environment with the name `ROLLBAR_ACCESS_TOKEN`.
     parameters:
-      environment:
+      project_environment:
         type: string
         default: production
         description: The Rollbar environment. Defaults to production.
@@ -40,4 +40,4 @@ jobs:
       - image: circleci/buildpack-deps:18.04-scm
     steps:
       - notify_deploy:
-          environment: << parameters.environment >>
+          environment: << parameters.project_environment >>

--- a/src/rollbar/orb.yml
+++ b/src/rollbar/orb.yml
@@ -11,7 +11,7 @@ commands:
       Add this as the last step of your the job that you
       use to deploy.
     parameters:
-      environment:
+      project_environment:
         type: string
         default: production
         description: The Rollbar environment. Defaults to production.
@@ -21,7 +21,7 @@ commands:
           command: |
             curl https://api.rollbar.com/api/1/deploy/ \
               --form access_token=$ROLLBAR_ACCESS_TOKEN \
-              --form environment=<< parameters.environment >> \
+              --form environment=<< parameters.project_environment >> \
               --form revision=$CIRCLE_SHA1 \
               --form local_username=$CIRCLE_USERNAME
 
@@ -40,4 +40,4 @@ jobs:
       - image: circleci/buildpack-deps:18.04-scm
     steps:
       - notify_deploy:
-          environment: << parameters.project_environment >>
+          project_environment: << parameters.project_environment >>


### PR DESCRIPTION
The `notify_deploy` job previously accepted an `environment` parameter, but
this wasn't passing the parameter through correctly. That's a bug in the orb
pipeline we'll need to address, but this renames the parameter to sidestep the
issue.