### PR TITLE
More versatile install methods for awscli

### DIFF
--- a/src/aws-cli/orb.yml
+++ b/src/aws-cli/orb.yml
@@ -22,20 +22,29 @@ commands:
       - run:
           name: Install AWS CLI
           command: |
-            if [[ $(command -v pip) == "" ]]; then
-              echo "PIP is required to install AWS CLI and is not available."
-              exit 1
-            else
-              if [[ $(command -v sudo) == "" ]]; then
-                echo "SUDO is required to install AWS CLI and is not available."
-                exit 1
+            export PIP=$(which pip pip3 | head -1)
+            if [[ -n $PIP ]]; then
+              if which sudo > /dev/null; then
+                sudo $PIP install awscli --upgrade
               else
-                if [[ $(command -v aws) == "" ]]; then
-                  sudo pip install awscli
-                else
-                  echo "AWS CLI is already installed."
-                fi
+                # This installs the AWS CLI to ~/.local/bin. Make sure that ~/.local/bin is in your $PATH.
+                $PIP install aws --upgrade --user
               fi
+            elif [[ $(which unzip curl | wc -l) -eq 2 ]]; then
+              cd
+              curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+              unzip awscli-bundle.zip
+              if which sudo > /dev/null; then
+                sudo ~/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+              else
+                # This installs the AWS CLI to the default location (~/.local/lib/aws) and create a symbolic link (symlink) at ~/bin/aws. Make sure that ~/bin is in your $PATH.
+                awscli-bundle/install -b ~/bin/aws
+              fi
+              rm -rf awscli-bundle*
+              cd -
+            else
+              echo "Unable to install AWS CLI. Please install pip."
+              exit 1
             fi
   configure:
     description: |


### PR DESCRIPTION
Do everything we can (short of installing packages) to install awscli.
*NOTE: If sudo is not present a $PATH change is necessary to use aws after installing it.