### PR TITLE
Auto promote manual hold

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,16 +11,29 @@ workflows:
     jobs:
       - lint
       - build
+
       - dev-release:
           requires:
             - build
             - lint
+
       - trigger-downstream:
           requires:
             - dev-release
           filters:
             branches:
               only: master
+
+      -  hold:
+          type: approval
+          requires:
+            - dev-release
+            - trigger-downstream
+
+      - dev-promote-patch:
+          requires:
+            - hold
+
 
 jobs:
   lint:
@@ -55,10 +68,32 @@ jobs:
           PROJECT="circleci/aws-code-deploy-orb-test/build"
           curl -X POST $BASE/$PROJECT?circle-token=$CIRCLECI_API_TOKEN
 
-  release:
+  dev-promote-patch:
     executor: cli
+    working-directory: ~/circleci-orbs/src
     steps:
       - checkout
+      - run:
+          name:
+          shell: /bin/bash -exo pipefail
+          command: |
+            COMMIT_RANGE=$(echo $CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g')
+
+            echo "Commit range: $COMMIT_RANGE"
+
+            for ORB in /*/; do
+              orbname=$(basename $ORB)
+
+              if [[ $(git diff $COMMIT_RANGE --name-status | grep "$orbname") ]]; then
+
+                echo "promoting circleci/${orbname}@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1} as patch release"
+
+                circleci orb publish promote circleci/${orbname}@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1} patch
+              else
+                echo "${orbname} not modified; not promoting"
+              fi
+            done
+
       ## walk the tree in orb-releases.yml (the path to which could be fed as a parameter to the command)
           ## For each, attempt to build the orb with the CLI, then if that's successful, register it.
           ## would look something like: `circleci orb build $PATH-TO-SRC $ORB-NAMESPACE $ORB-NAME $PATH-TO-BUILT-ORB; circleci orb register $PATH-TO-BUILT-ORB $REVISION`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ workflows:
             branches:
               only: master
 
-      -  hold:
+      - hold:
           type: approval
           requires:
             - dev-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,6 @@ jobs:
 
   dev-promote-patch:
     executor: cli
-    working-directory: ~/circleci-orbs/src
     steps:
       - checkout
       - run:
@@ -84,7 +83,7 @@ jobs:
 
             echo "Commit range: $COMMIT_RANGE"
 
-            for ORB in /*/; do
+            for ORB in src/*/; do
               orbname=$(basename $ORB)
 
               if [[ $(git diff $COMMIT_RANGE --name-status | grep "$orbname") ]]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
           curl -X POST $BASE/$PROJECT?circle-token=$CIRCLECI_API_TOKEN
 
   slack-notify-hold:
-    excecutor: cli
+    machine: true
     steps:
       - slack/notify:
           message: "Orbs from commit ${CIRCLE_SHA1} are ready for review/approval: https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,9 @@ workflows:
       - dev-promote-patch:
           requires:
             - hold
+          filters:
+            branches:
+              only: master
 
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
 
                 circleci orb publish promote circleci/${orbname}@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1} patch
               else
-                echo "${orbname} not modified; not promoting"
+                echo "${orbname} not modified; no need to promote"
               fi
             done
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,9 @@ workflows:
           requires:
             - dev-release
             - trigger-downstream
+          filters:
+            branches:
+              only: master
 
       - dev-promote-patch:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  slack: circleci/slack@volatile
+
 executors:
   cli:
     docker:
@@ -24,11 +27,18 @@ workflows:
             branches:
               only: master
 
-      - hold:
-          type: approval
+      - slack-notify-hold:
           requires:
             - dev-release
             - trigger-downstream
+          filters:
+            branches:
+              only: master
+
+      - hold:
+          type: approval
+          requires:
+            - slack-notify-hold
           filters:
             branches:
               only: master
@@ -74,12 +84,25 @@ jobs:
           PROJECT="circleci/aws-code-deploy-orb-test/build"
           curl -X POST $BASE/$PROJECT?circle-token=$CIRCLECI_API_TOKEN
 
+  slack-notify-hold:
+    excecutor: cli
+    steps:
+      - slack/notify:
+          message: "Orbs from commit ${CIRCLE_SHA1} are ready for review/approval: https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+          mentions: rose,eddiewebb
+
   dev-promote-patch:
     executor: cli
     steps:
       - checkout
+
+      - slack/notify:
+          message: "Orb publishing was approved for any orbs modified in commit ${CIRCLE_SHA1}: https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+          mentions: rose,eddiewebb
+
+
       - run:
-          name:
+          name: Publish any modified orbs
           shell: /bin/bash -exo pipefail
           command: |
             COMMIT_RANGE=$(echo $CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,14 @@ jobs:
     executor: cli
     steps:
       - checkout
-      - run: "sh scripts/dev-release.sh"
+      - run:
+          name: Publish dev releases of any modified orbs
+          command: |
+            COMMIT_RANGE=$(echo $CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g')
+
+            echo "Commit range: $COMMIT_RANGE"
+
+            "sh scripts/dev-release.sh"
 
   trigger-downstream:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
 
             echo "Commit range: $COMMIT_RANGE"
 
-            "sh scripts/dev-release.sh"
+            bash scripts/dev-release.sh
 
   trigger-downstream:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,19 +26,12 @@ workflows:
           filters:
             branches:
               only: master
-
-      - slack-notify-hold:
-          requires:
-            - dev-release
-            - trigger-downstream
-          filters:
-            branches:
-              only: master
+          context: orb-publishing
 
       - hold:
           type: approval
           requires:
-            - slack-notify-hold
+            - trigger-downstream
           filters:
             branches:
               only: master
@@ -49,6 +42,7 @@ workflows:
           filters:
             branches:
               only: master
+          context: orb-publishing
 
 
 jobs:
@@ -84,12 +78,9 @@ jobs:
           PROJECT="circleci/aws-code-deploy-orb-test/build"
           curl -X POST $BASE/$PROJECT?circle-token=$CIRCLECI_API_TOKEN
 
-  slack-notify-hold:
-    machine: true
-    steps:
       - slack/notify:
           message: "Orbs from commit ${CIRCLE_SHA1} are ready for review/approval: https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
-          mentions: rose,eddiewebb
+          mentions: "${ROSE_SLACK_UUID},{EDDIE_SLACK_UUID}$"
 
   dev-promote-patch:
     executor: cli
@@ -98,7 +89,7 @@ jobs:
 
       - slack/notify:
           message: "Orb publishing was approved for any orbs modified in commit ${CIRCLE_SHA1}: https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
-          mentions: rose,eddiewebb
+          mentions: "${ROSE_SLACK_UUID},{EDDIE_SLACK_UUID}$"
 
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
       - run:
           name: Publish dev releases of any modified orbs
           command: |
-            echo "Files changes: $(git log -1 --format="" --name-only)""
+            echo 'Files changed: $(git log -1 --format="" --name-only)'
 
             bash scripts/dev-release.sh
 
@@ -101,7 +101,7 @@ jobs:
           name: Publish any modified orbs
           shell: /bin/bash -exo pipefail
           command: |
-            echo "Files changes: $(git log -1 --format="" --name-only)""
+            echo 'Files changed: $(git log -1 --format="" --name-only)'
 
             for ORB in src/*/; do
               orbname=$(basename $ORB)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
       - run:
           name: Publish dev releases of any modified orbs
           command: |
-            echo 'Files changed: $(git log -1 --format="" --name-only)'
+            echo "Files changed: $(git log -1 --format="" --name-only)"
 
             bash scripts/dev-release.sh
 
@@ -101,7 +101,7 @@ jobs:
           name: Publish any modified orbs
           shell: /bin/bash -exo pipefail
           command: |
-            echo 'Files changed: $(git log -1 --format="" --name-only)'
+            echo "Files changed: $(git log -1 --format="" --name-only)"
 
             for ORB in src/*/; do
               orbname=$(basename $ORB)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,9 @@ jobs:
       - run:
           name: Publish dev releases of any modified orbs
           command: |
-            echo "Files changed: $(git log -1 --format="" --name-only)"
+            GIT_LOG=$(git log -1 --format="" --name-only)
+
+            echo "Files changed:" $GIT_LOG
 
             bash scripts/dev-release.sh
 
@@ -101,7 +103,9 @@ jobs:
           name: Publish any modified orbs
           shell: /bin/bash -exo pipefail
           command: |
-            echo "Files changed: $(git log -1 --format="" --name-only)"
+            GIT_LOG=$(git log -1 --format="" --name-only)
+
+            echo "Files changed:" $GIT_LOG
 
             for ORB in src/*/; do
               orbname=$(basename $ORB)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,9 +68,7 @@ jobs:
       - run:
           name: Publish dev releases of any modified orbs
           command: |
-            COMMIT_RANGE=$(echo $CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g')
-
-            echo "Commit range: $COMMIT_RANGE"
+            echo "Files changes: $(git log -1 --format="" --name-only)""
 
             bash scripts/dev-release.sh
 
@@ -103,14 +101,12 @@ jobs:
           name: Publish any modified orbs
           shell: /bin/bash -exo pipefail
           command: |
-            COMMIT_RANGE=$(echo $CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g')
-
-            echo "Commit range: $COMMIT_RANGE"
+            echo "Files changes: $(git log -1 --format="" --name-only)""
 
             for ORB in src/*/; do
               orbname=$(basename $ORB)
 
-              if [[ $(git diff $COMMIT_RANGE --name-status | grep "$orbname") ]]; then
+              if [[ $(git log -1 --format="" --name-only | grep "$orbname") ]]; then
 
                 echo "promoting circleci/${orbname}@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1} as patch release"
 

--- a/scripts/dev-release.sh
+++ b/scripts/dev-release.sh
@@ -12,13 +12,9 @@
 # TODO - it may be overkill to always publish all on the branch
 # TODO - this probably shouldn't silently fail to publish some of the orbs
 
-COMMIT_RANGE=$(echo $CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g')
-
-echo "Commit range: $COMMIT_RANGE"
-
 for ORB in src/*/; do
   orbname=$(basename $ORB)
-  if [[ $(git diff $COMMIT_RANGE --name-status | grep "$orbname") ]]; then
+  if [[ $(git log -1 --format="" --name-only | grep "$orbname") ]]; then
     (ls ${ORB}orb.yml && echo "orb.yml found, attempting to publish...") || echo "No orb.yml file was found - the next line is expected to fail."
     if [ -z "$CIRCLECI_API_TOKEN" ]; then
       circleci orb publish ${ORB}orb.yml circleci/${orbname}@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1}

--- a/scripts/dev-release.sh
+++ b/scripts/dev-release.sh
@@ -11,13 +11,22 @@
 
 # TODO - it may be overkill to always publish all on the branch
 # TODO - this probably shouldn't silently fail to publish some of the orbs
+
+COMMIT_RANGE=$(echo $CIRCLE_COMPARE_URL | sed 's:^.*/compare/::g')
+
+echo "Commit range: $COMMIT_RANGE"
+
 for ORB in src/*/; do
   orbname=$(basename $ORB)
-  (ls ${ORB}orb.yml && echo "orb.yml found, attempting to publish...") || echo "No orb.yml file was found - the next line is expected to fail."
-  if [ -z "$CIRCLECI_API_TOKEN" ]; then
-    circleci orb publish ${ORB}orb.yml circleci/${orbname}@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1}
+  if [[ $(git diff $COMMIT_RANGE --name-status | grep "$orbname") ]]; then
+    (ls ${ORB}orb.yml && echo "orb.yml found, attempting to publish...") || echo "No orb.yml file was found - the next line is expected to fail."
+    if [ -z "$CIRCLECI_API_TOKEN" ]; then
+      circleci orb publish ${ORB}orb.yml circleci/${orbname}@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1}
+    else
+      circleci orb publish ${ORB}orb.yml circleci/${orbname}@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1} --token $CIRCLECI_API_TOKEN
+    fi
   else
-    circleci orb publish ${ORB}orb.yml circleci/${orbname}@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1} --token $CIRCLECI_API_TOKEN
+    echo "${orbname} not modified; no need to promote"
   fi
   echo "---------------------------"
 done


### PR DESCRIPTION
until we get these orbs into their own repos, we need some kind of automated publishing option so we aren't combing through commits looking to see what we need to publish

this will loop through the folders in `/src`, check if they've been modified, & if so, promote the version we published to `dev` in a previous job, as a patch release

as an additional safeguard, there is a manual approval job before the publish job