### PR TITLE
Bump circleci/aws-cli to 0.1.4 in aws-code-deploy Orb

### DIFF
--- a/src/aws-code-deploy/orb.yml
+++ b/src/aws-code-deploy/orb.yml
@@ -23,7 +23,7 @@ examples:
                 bundle-key: myS3BucketKey
 
 orbs:
-  aws-cli: circleci/aws-cli@0.0.1
+  aws-cli: circleci/aws-cli@0.1.4
 
 commands:
   create-application:


### PR DESCRIPTION
Use the latest `circleci/aws-cli` version(`@0.1.4`) in aws-code-deploy orb.