### PR TITLE
Denote `docker push` as a deploy step

### DIFF
--- a/src/docker-publish/orb.yml
+++ b/src/docker-publish/orb.yml
@@ -155,7 +155,7 @@ commands:
         type: string
         default: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
     steps:
-      - run:
+      - deploy:
           name: Push Docker Image
           command: docker push << parameters.registry >>/<< parameters.image >>
 


### PR DESCRIPTION
In parallel jobs, use of this individual command should result in only one execution.