### PR TITLE
Fix docker-publish orb's `deploy` name collision

### DIFF
--- a/src/docker-publish/orb.yml
+++ b/src/docker-publish/orb.yml
@@ -155,9 +155,12 @@ commands:
         type: string
         default: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
     steps:
-      - deploy:
+      - run:
           name: Push Docker Image
-          command: docker push << parameters.registry >>/<< parameters.image >>
+          command: |
+            if [[ $CIRCLE_NODE_INDEX == 0 ]]; then
+              docker push << parameters.registry >>/<< parameters.image >>
+            fi
 
 jobs:
   publish:

--- a/src/node/orb.yml
+++ b/src/node/orb.yml
@@ -3,6 +3,27 @@ version: 2.1
 description: |
   Simplify common tasks for building and testing Node projects
 
+examples:
+  standard_node_project:
+    description: A common Node workflow
+    usage:
+      version: 2.1
+
+      orbs:
+        node: circleci/node@1.0.0
+
+      workflows:
+        build-test:
+          jobs:
+            - build
+            - test:
+                requires:
+                  - build
+
+      jobs:
+        build:
+          executor: node/default
+
 executors:
   default:
     parameters:

--- a/src/node/orb.yml
+++ b/src/node/orb.yml
@@ -3,27 +3,6 @@ version: 2.1
 description: |
   Simplify common tasks for building and testing Node projects
 
-examples:
-  standard_node_project:
-    description: A common Node workflow
-    usage:
-      version: 2.1
-
-      orbs:
-        node: circleci/node@1.0.0
-
-      workflows:
-        build-test:
-          jobs:
-            - build
-            - test:
-                requires:
-                  - build
-
-      jobs:
-        build:
-          executor: node/default
-
 executors:
   default:
     parameters:


### PR DESCRIPTION
@sbonami correctly noted that we likely only want the docker-publish orb's `deploy` command to run in a single container (there may be other orbs where we want to make this fix, as well):

https://github.com/CircleCI-Public/circleci-orbs/pull/76

however as the command name is `deploy`, there's a name collision with our special `deploy` step. change this to a `run` step w/ a check for `$CIRCLE_NODE_INDEX` to accomplish the same thing w/o collisions for now.