### PR TITLE
Node: Align `with-cache` cmd's `dir` default with working directory

### DIFF
--- a/src/node/orb.yml
+++ b/src/node/orb.yml
@@ -122,7 +122,7 @@ commands:
       dir:
         type: string
         description: Filepath to your Node modules.
-        default: "~/node_modules/"
+        default: ${CIRCLE_WORKING_DIRECTORY}/node_modules
       cache-key:
         type: string
         description: File to use as a Node cache checksum.


### PR DESCRIPTION
The Node orb's `with-cache` default for `dir` doesn't play well with the existing `working_directory` configuration. A more sane default using the `CIRCLE_WORKING_DIRECTORY` environment variable should provide less need to specify a value for this parameter.