### PR TITLE
Fixed. can't deploy non-master branch to Heroku

### DIFF
--- a/src/heroku/orb.yml
+++ b/src/heroku/orb.yml
@@ -100,7 +100,7 @@ commands:
           name: Deploy branch to Heroku via git push
           command: |
             if [[ "<< parameters.only-branch >>" == "" ]] || [[ "${CIRCLE_BRANCH}" == "<< parameters.only-branch >>" ]]; then
-              git push https://heroku:<< parameters.api-key >>@git.heroku.com/<< parameters.app-name >>.git << parameters.branch >>
+              git push https://heroku:<< parameters.api-key >>@git.heroku.com/<< parameters.app-name >>.git << parameters.branch >>:master
             fi
 
 jobs:


### PR DESCRIPTION
I want to deploy a non-master branch (e.g. `develop`), but couldn't.

# .circleci/config.yml
```yml
version: 2.1

orbs:
  heroku: circleci/heroku@0.0.2

workflows:
  version: 2

  deploy:
    jobs:
      - heroku/deploy-via-git:
          filters:
            branches:
              only: develop
```

# Expected
Deploy `develop` branch to Heroku

# Actual
```
Counting objects: 12, done.
Delta compression using up to 36 threads.
Compressing objects: 100% (8/8), done.
Writing objects: 100% (12/12), 1.93 KiB | 1.93 MiB/s, done.
Total 12 (delta 6), reused 10 (delta 4)
remote: Pushed to non-master branch, skipping build.        
To https://git.heroku.com/my-heroku-app.git
 * [new branch]      develop -> develop
```

# Why & workaround
If deploy non-master branch, we must explicitly specify the `master` branch to remote.

c.f. https://devcenter.heroku.com/articles/git#deploying-from-a-branch-besides-master
