### PR TITLE
arguments to s3-sync, docker build w/o publish, docker extra build args => master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
 
                 (ls ${ORB}orb.yml && echo "orb.yml found, attempting to publish...") || echo "No orb.yml file was found - the next line is expected to fail."
 
-                circleci orb publish ${ORB}orb.yml circleci/${orbname}@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1} --token $CIRCLECI_API_TOKEN
+                circleci orb publish ${ORB}orb.yml circleci/${orbname}@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1:0:7} --token $CIRCLECI_API_TOKEN
               else
                 echo "${orbname} not modified; no need to promote"
               fi
@@ -137,9 +137,9 @@ jobs:
               orbname=$(basename $ORB)
               if [[ $(git diff $COMMIT_RANGE --name-status | grep "$orbname") ]]; then
 
-                echo "promoting circleci/${orbname}@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1} as patch release"
+                echo "promoting circleci/${orbname}@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1:0:7} as patch release"
 
-                circleci orb publish promote circleci/${orbname}@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1} patch --token $CIRCLECI_API_TOKEN
+                circleci orb publish promote circleci/${orbname}@dev:${CIRCLE_BRANCH}-${CIRCLE_SHA1:0:7} patch --token $CIRCLECI_API_TOKEN
               else
                 echo "${orbname} not modified; no need to promote"
               fi

--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ For more info on use of the CLI see the help on orb publishing inside the CLI:
 `circleci orb publish --help`
 
 TODO: The above will default to use the main circleci.com service. If you are publishing orbs to a registry on your private CircleCI server installation you can pass your root domain in as an argument or by setting it in your `.circleci/config.yml` file.
+
+## Contributing
+We welcome [issues](https://github.com/CircleCI-Public/circleci-orbs/issues) (bugs or feature requests) and [pull requests](https://github.com/CircleCI-Public/circleci-orbs/pulls)!
+
+All pull requests will initially merge to `staging`, triggering automatic dev releases of any modified orbs and allowing open-source contributors working on forks of the repository to test out their code changes. Once we have confirmed the stability/functionality of modifications (via either manual or to-be-added automated integration testing), we will merge the changes in `staging` to `master`.

--- a/src/docker-publish/orb.yml
+++ b/src/docker-publish/orb.yml
@@ -281,8 +281,11 @@ jobs:
           condition: << parameters.after_checkout >>
           steps: << parameters.after_checkout >>
       - setup_remote_docker
-      - check:
-          registry: << parameters.registry >>
+      - when:
+          condition: <<parameters.deploy>>
+          steps:
+            - check:
+                registry: << parameters.registry >>
       - when:
           name: Run before_build lifecycle hook steps.
           condition: << parameters.before_build >>

--- a/src/docker-publish/orb.yml
+++ b/src/docker-publish/orb.yml
@@ -257,7 +257,7 @@ jobs:
       extra_build_args:
         description: Name of environment file to pass to docker.
         type: env_var_name
-        default: __EMPTY
+        default: ""
       after_checkout:
         description: Optional steps to run after checking out the code.
         type: steps

--- a/src/docker-publish/orb.yml
+++ b/src/docker-publish/orb.yml
@@ -197,8 +197,8 @@ commands:
         default: docker.io
       extra_build_args:
         description: >
-          Extra arguments to pass to docker build. For examples, see
-          https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg
+          Extra flags to pass to docker build. For examples, see
+          https://docs.docker.com/engine/reference/commandline/build
         type: string
         default: ""
     steps:
@@ -255,8 +255,10 @@ jobs:
         type: string
         default: docker.io
       extra_build_args:
-        description: Name of environment file to pass to docker.
-        type: env_var_name
+        description: >
+          Extra flags to pass to docker build. For examples, see
+          https://docs.docker.com/engine/reference/commandline/build
+        type: string
         default: ""
       after_checkout:
         description: Optional steps to run after checking out the code.

--- a/src/docker-publish/orb.yml
+++ b/src/docker-publish/orb.yml
@@ -129,14 +129,14 @@ examples:
     usage:
       version: 2.1
 
-    orbs:
-      docker-publish: circleci/docker-publish@1.0.0
+      orbs:
+        docker-publish: circleci/docker-publish@1.0.0
 
-    workflows:
-      extra_build_args:
-        jobs:
-          - docker-publish/publish:
-              extra_build_args: --build-arg FOO=bar --build-arg BAZ=qux
+      workflows:
+        extra_build_args:
+          jobs:
+            - docker-publish/publish:
+                extra_build_args: --build-arg FOO=bar --build-arg BAZ=qux
 
 executors:
   docker:

--- a/src/docker-publish/orb.yml
+++ b/src/docker-publish/orb.yml
@@ -122,6 +122,22 @@ examples:
           jobs:
             - check_and_build_only
 
+  with_extra_build_args:
+    description: >
+      Build/publish a docker image with extra build arguments
+
+    usage:
+      version: 2.1
+
+    orbs:
+      docker-publish: circleci/docker-publish@1.0.0
+
+    workflows:
+      extra_build_args:
+        jobs:
+          - docker-publish/publish:
+              extra_build_args: --build-arg FOO=bar --build-arg BAZ=qux
+
 executors:
   docker:
     description: The docker container to use when running docker-publish builds
@@ -180,13 +196,20 @@ commands:
         type: string
         default: docker.io
       extra_build_args:
-        description: Name of environment file to pass to docker.
-        type: env_var_name
-        default: __EMPTY
+        description: >
+          Extra arguments to pass to docker build. For examples, see
+          https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg
+        type: string
+        default: ""
     steps:
       - run:
           name: Build Docker Image
-          command: __EMPTY= docker build ${<< parameters.extra_build_args >>} -f << parameters.dockerfile >> -t << parameters.registry >>/<< parameters.image >>:<< parameters.tag >> << parameters.path >>
+          command: |
+            docker build \
+              <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
+              -f << parameters.dockerfile >> -t \
+              << parameters.registry >>/<< parameters.image >>:<< parameters.tag >> \
+              << parameters.path >>
   deploy:
     description: Deploy docker image to a registry.
     parameters:


### PR DESCRIPTION
from https://github.com/CircleCI-Public/circleci-orbs/pull/97 : 

> Hello!
> 
> I tried to use the `s3 sync` orb, but stumbled because we need to provide more arguments. We have a directory of static assets that we upload, and we need to set cache-control and public acls for these. I *think* this PR should do that. I'm happy to iterate if it needs more work!
> 
> Ideally I think I would have removed the `overwrite:` flag from the sync command as well, since "overwrite" poorly describes what adding the `--delete` flag to s3 sync actually does:
> 
> > --delete  (boolean)  Files that exist in the destination but not in the source are deleted during sync.
> 
> However, I didn't want to remove backwards compatibility in this PR. Maybe for version 2 ;-)