### PR TITLE
docker-publish: Fix executor example

### DIFF
--- a/src/docker-publish/orb.yml
+++ b/src/docker-publish/orb.yml
@@ -110,7 +110,7 @@ examples:
 
       jobs:
         check_and_build_only:
-          executor: docker
+          executor: docker-publish/docker
           steps:
             - checkout
             - setup_remote_docker


### PR DESCRIPTION
The executor needs to be prefixed with the orb name, otherwise an error as following ensues:

```
$ circleci config validate
Error: Error calling workflow: 'test'
Error calling job: 'prepare_image'
Cannot find a definition for executor named docker
```