### PR TITLE
remove manual hold for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,17 +29,17 @@ workflows:
               only: master
           context: orb-publishing
 
-      - hold:
-          type: approval
-          requires:
-            - trigger-downstream
-          filters:
-            branches:
-              only: master
+      # - hold:
+      #     type: approval
+      #     requires:
+      #       - trigger-downstream
+      #     filters:
+      #       branches:
+      #         only: master
 
       - dev-promote-patch:
           requires:
-            - hold
+            - trigger-downstream # hold
           filters:
             branches:
               only: master


### PR DESCRIPTION
we now have a two-branch BTD process, in which changes are merged into `staging` from feature branches, & then from `staging` to `master`, so i think the manual approval job is now a bit unecessary