### PR TITLE
Add a lein-nvd orb

### DIFF
--- a/src/lein-nvd/orb.yml
+++ b/src/lein-nvd/orb.yml
@@ -1,24 +1,34 @@
 ---
 version: 2.1
 
-description: Scan a Clojure project for vulnerabilities using lein-nvd.
+description: >
+  Scan a Clojure project for vulnerabilities using lein-nvd.
 
 executors:
   lein_nvd_default_executor:
-    description: A docker container that can be used to run lein nvd check.
+    description: A Docker container that can be used to run lein nvd check
+    parameters:
+      tag:
+        type: string
+        default: latest
+        description: >
+          Variant of circleci/clojure image to use: 
+          http://hub.docker.com/r/circleci/clojure/tags
+
     docker:
-      - image: circleci/clojure
+      - image: circleci/clojure:<<parameters.tag>>
 
 commands:
   run_lein_nvd:
     description: Scan a Clojure project for vulnerabilities using lein-nvd.
     parameters:
       suppressions_file:
+        type: string
         description: |
           The location of an XML file to suppress false positive results from
           the report. The format is documented at
           https://jeremylong.github.io/DependencyCheck/general/suppression.html
-        type: string
+
     steps:
       - run:
           name: Turn off :pedantic? :abort
@@ -26,6 +36,7 @@ commands:
             if grep -q ':pedantic? :abort' project.clj; then
               lein change ':pedantic?' set :warn
             fi
+      
       - run:
           name: Check for conflicting configuration
           command: |
@@ -37,6 +48,7 @@ commands:
               echo ":nvd found in project.clj, aborting"
               exit 1
             fi
+      
       - run:
           name: Add lein-nvd
           command: |
@@ -61,30 +73,38 @@ commands:
               echo " :suppression-file \"${suppress_xml}\"" >> ${profiles}
             fi
             echo "}}}" >> ${profiles}
+      
       - restore_cache:
           key: orb-lein-nvd
+      
       - run: lein nvd update
+      
       - save_cache:
           key: orb-lein-nvd
           paths: /tmp/nvd/data
+      
       - run: lein nvd check
 
 jobs:
   lein_nvd:
     description: Scan a Clojure project for vulnerabilities using lein-nvd.
     executor: <<parameters.executor>>
+
     parameters:
       executor:
         description: The name of a custom executor to use
         type: executor
         default: lein_nvd_default_executor
+
       suppressions_file:
         description: |
           The location of an XML file to suppress false positive results from
           the report. The format is documented at
           https://jeremylong.github.io/DependencyCheck/general/suppression.html
         type: string
+        
     steps:
       - checkout
+
       - run_lein_nvd:
           suppressions_file: <<parameters.suppressions_file>>

--- a/src/lein-nvd/orb.yml
+++ b/src/lein-nvd/orb.yml
@@ -1,4 +1,3 @@
----
 version: 2.1
 
 description: >

--- a/src/lein-nvd/orb.yml
+++ b/src/lein-nvd/orb.yml
@@ -1,0 +1,90 @@
+---
+version: 2.1
+
+description: Scan a Clojure project for vulnerabilities using lein-nvd.
+
+executors:
+  lein_nvd_default_executor:
+    description: A docker container that can be used to run lein nvd check.
+    docker:
+      - image: circleci/clojure
+
+commands:
+  run_lein_nvd:
+    description: Scan a Clojure project for vulnerabilities using lein-nvd.
+    parameters:
+      suppressions_file:
+        description: |
+          The location of an XML file to suppress false positive results from
+          the report. The format is documented at
+          https://jeremylong.github.io/DependencyCheck/general/suppression.html
+        type: string
+    steps:
+      - run:
+          name: Turn off :pedantic? :abort
+          command: |
+            if grep -q ':pedantic? :abort' project.clj; then
+              lein change ':pedantic?' set :warn
+            fi
+      - run:
+          name: Check for conflicting configuration
+          command: |
+            if grep -q 'lein-nvd' project.clj; then
+              echo "lein-nvd found in project.clj, aborting"
+              exit 1
+            fi
+            if grep -q ':nvd' project.clj; then
+              echo ":nvd found in project.clj, aborting"
+              exit 1
+            fi
+      - run:
+          name: Add lein-nvd
+          command: |
+            suppress_xml="<<parameters.suppressions_file>>"
+            if [[ -n "${suppress_xml}" ]]; then
+              if [[ ! -f "${suppress_xml}" ]]; then
+                echo "${suppress_xml} does not exist, aborting"
+                exit 1
+              fi
+            else
+              if [[ -f ".nvd/suppression.xml" ]]; then
+                suppress_xml=".nvd/suppression.xml"
+              fi
+            fi
+
+            mkdir -p "${HOME}/.lein"
+            profiles="${HOME}/.lein/profiles"
+            echo "{:user {" > ${profiles}
+            echo ':plugins [[lein-nvd "0.6.0"]]' >> ${profiles}
+            echo ':nvd {:data-directory "/tmp/nvd/data"' >> ${profiles}
+            if [[ -n "${suppress_xml}" ]]; then
+              echo " :suppression-file \"${suppress_xml}\"" >> ${profiles}
+            fi
+            echo "}}}" >> ${profiles}
+      - restore_cache:
+          key: orb-lein-nvd
+      - run: lein nvd update
+      - save_cache:
+          key: orb-lein-nvd
+          paths: /tmp/nvd/data
+      - run: lein nvd check
+
+jobs:
+  lein_nvd:
+    description: Scan a Clojure project for vulnerabilities using lein-nvd.
+    executor: <<parameters.executor>>
+    parameters:
+      executor:
+        description: The name of a custom executor to use
+        type: executor
+        default: lein_nvd_default_executor
+      suppressions_file:
+        description: |
+          The location of an XML file to suppress false positive results from
+          the report. The format is documented at
+          https://jeremylong.github.io/DependencyCheck/general/suppression.html
+        type: string
+    steps:
+      - checkout
+      - run_lein_nvd:
+          suppressions_file: <<parameters.suppressions_file>>

--- a/src/lein-nvd/orb.yml
+++ b/src/lein-nvd/orb.yml
@@ -11,7 +11,7 @@ executors:
         type: string
         default: latest
         description: >
-          Variant of circleci/clojure image to use: 
+          Variant of circleci/clojure image to use:
           http://hub.docker.com/r/circleci/clojure/tags
 
     docker:
@@ -35,7 +35,7 @@ commands:
             if grep -q ':pedantic? :abort' project.clj; then
               lein change ':pedantic?' set :warn
             fi
-      
+
       - run:
           name: Check for conflicting configuration
           command: |
@@ -47,7 +47,7 @@ commands:
               echo ":nvd found in project.clj, aborting"
               exit 1
             fi
-      
+
       - run:
           name: Add lein-nvd
           command: |
@@ -72,16 +72,16 @@ commands:
               echo " :suppression-file \"${suppress_xml}\"" >> ${profiles}
             fi
             echo "}}}" >> ${profiles}
-      
+
       - restore_cache:
           key: orb-lein-nvd
-      
+
       - run: lein nvd update
-      
+
       - save_cache:
           key: orb-lein-nvd
           paths: /tmp/nvd/data
-      
+
       - run: lein nvd check
 
 jobs:
@@ -101,7 +101,7 @@ jobs:
           the report. The format is documented at
           https://jeremylong.github.io/DependencyCheck/general/suppression.html
         type: string
-        
+
     steps:
       - checkout
 


### PR DESCRIPTION
Use this to scan Clojure projects for security vulnerabilities.

### Checklist

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

Setting up [lein-nvd](https://github.com/rm-hull/lein-nvd) to scan Clojure projects for vulnerabilities is easy but tedious. It would be nicer to use an orb for this.

### Description

Added an orb which injects `lein-nvd` into a user profile, turns off `:pedantic? :abort` if necessary and then runs `lein nvd check` on the repository. The NVD database is cached to speed up second and subsequent runs.