### PR TITLE
Add git push support to Heroku orb.

### DIFF
--- a/src/heroku/orb.yml
+++ b/src/heroku/orb.yml
@@ -87,6 +87,10 @@ commands:
         description:
           Deploy the given branch. The default value is your current branch.
         default: "$CIRCLE_BRANCH"
+      force:
+        type: boolean
+        description: "Whether or not to force the git push (i.e. `git push -f`). Defaults to false."
+        default: false
       only-branch:
         type: string
         description:
@@ -100,8 +104,12 @@ commands:
       - run:
           name: Deploy branch to Heroku via git push
           command: |
+            if << parameters.force >>;then
+              force="-f"
+            fi
+
             if [[ "<< parameters.only-branch >>" == "" ]] || [[ "${CIRCLE_BRANCH}" == "<< parameters.only-branch >>" ]]; then
-              git push https://heroku:<< parameters.api-key >>@git.heroku.com/<< parameters.app-name >>.git << parameters.branch >>:master
+              git push $force https://heroku:<< parameters.api-key >>@git.heroku.com/<< parameters.app-name >>.git << parameters.branch >>:master
             fi
 
 jobs:


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Fixes #121.

### Description

For the Heroku orb, adds a `force` boolean parameter to force a Git push.  Depending on someone's deployment workflow, this may be needed. The default is false meaning it doesn't force.