### PR TITLE
Node: Upgrade npm with global.

### DIFF
--- a/src/node/orb.yml
+++ b/src/node/orb.yml
@@ -75,7 +75,7 @@ commands:
           steps:
             - run:
                 name: Install specific version of npm
-                command: sudo npm i npm@"<< parameters.npm_version >>"
+                command: sudo npm install -g npm@"<< parameters.npm_version >>"
             - run:
                 name: Workaround to address issues with using npm to upgrade npm
                 command: |


### PR DESCRIPTION
Fixed #87 

Use "global" scope when updating `npm`. This is what npm docs suggests to do: https://docs.npmjs.com/try-the-latest-stable-version-of-npm