### PR TITLE
feat: arguments support for aws deploy

### DIFF
--- a/src/aws-code-deploy/orb.yml
+++ b/src/aws-code-deploy/orb.yml
@@ -22,6 +22,24 @@ examples:
                 service-role-arn: myDeploymentGroupRoleARN
                 bundle-bucket: myApplicationS3Bucket
                 bundle-key: myS3BucketKey
+  override_credentials:
+    description: Deploy an application to AWS CodeDeploy with specific aws profile
+    usage:
+      version: 2.1
+
+      orbs:
+        aws-code-deploy: circleci/aws-code-deploy@1.0.0
+
+      workflows:
+        deploy_application:
+          jobs:
+            - aws-code-deploy/deploy:
+                application-name: myApplication
+                deployment-group: myDeploymentGroup
+                service-role-arn: myDeploymentGroupRoleARN
+                bundle-bucket: myApplicationS3Bucket
+                bundle-key: myS3BucketKey
+                arguments: '--profile assume_role'
 
 orbs:
   aws-cli: circleci/aws-cli@0.1.6

--- a/src/aws-code-deploy/orb.yml
+++ b/src/aws-code-deploy/orb.yml
@@ -33,6 +33,10 @@ commands:
         description:
           "The name of an AWS CodeDeploy application associated with the applicable IAM user or AWS account."
         type: string
+      arguments:
+        description: If you wish to pass any additional arguments to the aws deploy command
+        type: string
+        default: ''
     steps:
       - run:
           name: ensure-application-created
@@ -42,7 +46,7 @@ commands:
             if [ $? -ne 0 ]; then
               set -e
               echo "No application named << parameters.application-name >> found. Trying to create a new one"
-              aws deploy create-application --application-name << parameters.application-name >>
+              aws deploy create-application --application-name << parameters.application-name >><<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>
             else
               set -e
               echo "Application named << parameters.application-name >> already exists. Skipping creation."
@@ -67,6 +71,10 @@ commands:
         description:
           "The service role for a deployment group."
         type: string
+      arguments:
+        description: If you wish to pass any additional arguments to the aws deploy command
+        type: string
+        default: ''
     steps:
       - run:
           name: ensure-deployment-created
@@ -74,7 +82,7 @@ commands:
             set +e
             aws deploy get-deployment-group \
               --application-name << parameters.application-name >> \
-              --deployment-group-name << parameters.deployment-group >>
+              --deployment-group-name << parameters.deployment-group >><<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>
             if [ $? -ne 0 ]; then
               set -e
               echo "No deployment group named << parameters.deployment-group >> found. Trying to create a new one"
@@ -82,7 +90,7 @@ commands:
                 --application-name << parameters.application-name >> \
                 --deployment-group-name << parameters.deployment-group >> \
                 --deployment-config-name << parameters.deployment-config >> \
-                --service-role-arn << parameters.service-role-arn >>
+                --service-role-arn << parameters.service-role-arn >><<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>
             else
               set -e
               echo "Deployment group named << parameters.deployment-group >> already exists. Skipping creation."
@@ -112,6 +120,10 @@ commands:
           "The file type used for an application revision bundle. Currently defaults to 'zip'"
         type: string
         default: "zip"
+      arguments:
+        description: If you wish to pass any additional arguments to the aws deploy command
+        type: string
+        default: ''
     steps:
       - run:
           name: push-bundle
@@ -119,7 +131,7 @@ commands:
             aws deploy push \
               --application-name << parameters.application-name >> \
               --source << parameters.bundle-source >> \
-              --s3-location s3://<< parameters.bundle-bucket >>/<< parameters.bundle-key >>.<< parameters.bundle-type >>
+              --s3-location s3://<< parameters.bundle-bucket >>/<< parameters.bundle-key >>.<< parameters.bundle-type >><<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>
 
   deploy-bundle:
     parameters:
@@ -149,6 +161,10 @@ commands:
           "The file type used for an application revision bundle. Currently defaults to 'zip'"
         type: string
         default: "zip"
+      arguments:
+        description: If you wish to pass any additional arguments to the aws deploy command
+        type: string
+        default: ''
     steps:
       - run:
           name: deploy-bundle
@@ -159,7 +175,7 @@ commands:
                    --deployment-config-name << parameters.deployment-config >> \
                    --s3-location bucket=<< parameters.bundle-bucket >>,bundleType=<< parameters.bundle-type >>,key=<< parameters.bundle-key >>.<< parameters.bundle-type >> \
                    --output text \
-                   --query '[deploymentId]')
+                   --query '[deploymentId]'<<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>)
 
             STATUS=$(aws deploy get-deployment \
                       --deployment-id $ID \
@@ -171,17 +187,17 @@ commands:
               STATUS=$(aws deploy get-deployment \
                         --deployment-id $ID \
                         --output text \
-                        --query '[deploymentInfo.status]')
+                        --query '[deploymentInfo.status]'<<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>)
               sleep 5
             done
 
             if [[ $STATUS == "Failed" ]]; then
               echo "Deployment failed!"
-              aws deploy get-deployment --deployment-id $ID
+              aws deploy get-deployment --deployment-id $ID<<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>
               exit 1
             else
               echo "Deployment finished."
-              aws deploy get-deployment --deployment-id $ID
+              aws deploy get-deployment --deployment-id $ID<<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>
             fi
 
 jobs:
@@ -226,6 +242,10 @@ jobs:
           "The file type used for an application revision bundle. Currently defaults to 'zip'"
         type: string
         default: "zip"
+      arguments:
+        description: If you wish to pass any additional arguments to the aws deploy command
+        type: string
+        default: ''
     executor: aws-cli/default
     steps:
       - checkout
@@ -233,17 +253,20 @@ jobs:
       - aws-cli/configure
       - create-application:
           application-name: << parameters.application-name >>
+          arguments: << parameters.arguments >>
       - create-deployment-group:
           application-name: << parameters.application-name >>
           deployment-group: << parameters.deployment-group >>
           deployment-config: << parameters.deployment-config >>
           service-role-arn: << parameters.service-role-arn >>
+          arguments: << parameters.arguments >>
       - push-bundle:
           application-name: << parameters.application-name >>
           bundle-source: << parameters.bundle-source >>
           bundle-bucket: << parameters.bundle-bucket >>
           bundle-key: << parameters.bundle-key >>
           bundle-type: << parameters.bundle-type >>
+          arguments: << parameters.arguments >>
       - deploy-bundle:
           application-name: << parameters.application-name >>
           deployment-group: << parameters.deployment-group >>
@@ -251,3 +274,4 @@ jobs:
           bundle-bucket: << parameters.bundle-bucket >>
           bundle-key: << parameters.bundle-key >>
           bundle-type: << parameters.bundle-type >>
+          arguments: << parameters.arguments >>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

I tried to use the `aws-code-deploy/deploy-bundle` orb, but strumbled because we need to provide more arguments. We are using iam with role_arn so that `[default]` is not working, and we need to pass `--profile xxxxx` for these. I've tried but AWS_PROFILE and AWS_DEFAULT_PROFILE not cover this scenario. I think this PR should do that, I already do in my repo and seems works fine. I'm happy to iterate if it needs more work:)

Should I add any example...?

```
arguments: '--profile abc123'
```

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

* add `arguments` parameter to `create-application`, `create-deployment-group`, `push-bundle` and `deploy-bundle` commands.
* add `arguments` parameter to job `deploy`.