### PR TITLE
fix: missing arguments on get-deployment

### DIFF
--- a/src/aws-code-deploy/orb.yml
+++ b/src/aws-code-deploy/orb.yml
@@ -60,7 +60,7 @@ commands:
           name: ensure-application-created
           command: |
             set +e
-            aws deploy get-application --application-name << parameters.application-name >>
+            aws deploy get-application --application-name << parameters.application-name >><<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>
             if [ $? -ne 0 ]; then
               set -e
               echo "No application named << parameters.application-name >> found. Trying to create a new one"

--- a/src/aws-code-deploy/orb.yml
+++ b/src/aws-code-deploy/orb.yml
@@ -198,7 +198,7 @@ commands:
             STATUS=$(aws deploy get-deployment \
                       --deployment-id $ID \
                       --output text \
-                      --query '[deploymentInfo.status]')
+                      --query '[deploymentInfo.status]'<<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>)
 
             while [[ $STATUS == "Created" || $STATUS == "InProgress" || $STATUS == "Pending" ]]; do
               echo "Status: $STATUS..."


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

fix for missing argument on get-deployment.

> https://github.com/CircleCI-Public/circleci-orbs/pull/140

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

@iynere Sorry about bother you with silly mistake. I've test 0.0.8 on my lab and found missing argument on deploy-bundle and  create-application jobs.