### PR TITLE
Adding parameter for custom settings file

### DIFF
--- a/src/maven/orb.yml
+++ b/src/maven/orb.yml
@@ -90,7 +90,7 @@ examples:
         maven_test:
           jobs:
             - maven/test:
-                settings_file: .circleci/settings.xml
+                settings_file: ci-settings.xml
 
 executors:
   maven:

--- a/src/maven/orb.yml
+++ b/src/maven/orb.yml
@@ -76,6 +76,22 @@ examples:
             - maven/test:
                 executor: my-executor
 
+  custom_settings_file:
+    description: |
+      If you want to use a custom maven settings file.
+
+    usage:
+      version: 2.1
+
+      orbs:
+        maven: circleci/maven@1.0.0
+
+      workflows:
+        maven_test:
+          jobs:
+            - maven/test:
+                settings_file: .circleci/settings.xml
+
 executors:
   maven:
     description: The docker container to use when running Maven builds
@@ -97,6 +113,9 @@ commands:
       The cache-key is generated from any files named `pom.xml` that are
       present in the `working_directory`.
     parameters:
+      settings_file:
+        description: Specify a custom settings file to use (optional)
+        type: string
       steps:
         type: steps
     steps:
@@ -105,9 +124,18 @@ commands:
           command: find . -name 'pom.xml' -exec cat {} + | shasum | awk '{print $1}' > /tmp/maven_cache_seed
       - restore_cache:
           key: maven-{{ checksum "/tmp/maven_cache_seed" }}
-      - run:
-          name: Install Dependencies
-          command: mvn dependency:go-offline
+      - when:
+          condition: << parameters.settings_file >>
+          steps:
+            - run:
+                name: Install Dependencies
+                command: mvn dependency:go-offline --settings '<< parameters.settings_file >>'
+      - unless:
+          condition: << parameters.settings_file >>
+          steps:
+            - run:
+                name: Install Dependencies
+                command: mvn dependency:go-offline
       - steps: << parameters.steps >>
       - save_cache:
           paths:
@@ -145,14 +173,27 @@ jobs:
         description: The path to the test results.
         type: string
         default: target/surefire-reports
+      settings_file:
+        description: Specify a custom settings file to use (optional)
+        type: string
 
     steps:
       - checkout
       - with_cache:
+          settings_file: << parameters.settings_file >>
           steps:
-            - run:
-                name: Run Tests
-                command: mvn << parameters.command >>
+            - when:
+                condition: << parameters.settings_file >>
+                steps:
+                  - run:
+                      name: Run Tests
+                      command: mvn << parameters.command >> --settings '<< parameters.settings_file >>'
+            - unless:
+                condition: << parameters.settings_file >>
+                steps:
+                  - run:
+                      name: Run Tests
+                      command: mvn << parameters.command >>
       - process_test_results:
           test_results_path: << parameters.test_results_path >>
 
@@ -171,6 +212,9 @@ jobs:
         description: The maven command to run.
         type: string
         default: verify
+      settings_file:
+        description: Specify a custom settings file to use (optional)
+        type: string
       test_results_path:
         description: The path to the test results.
         type: string
@@ -232,9 +276,19 @@ jobs:
       - store_artifacts:
           path: .circleci/tests/
       - with_cache:
+          settings_file: << parameters.settings_file >>
           steps:
-            - run:
-                name: Run Tests
-                command: mvn << parameters.command >> -Dsurefire.excludesFile=.circleci/tests/surefire_classnames_ignore_list -Dfailsafe.excludesFile=.circleci/tests/failsafe_classnames_ignore_list
+            - when:
+                condition: << parameters.settings_file >>
+                steps:
+                  - run:
+                      name: Run Tests
+                      command: mvn << parameters.command >> -Dsurefire.excludesFile=.circleci/tests/surefire_classnames_ignore_list -Dfailsafe.excludesFile=.circleci/tests/failsafe_classnames_ignore_list --settings '<< parameters.settings_file >>'
+            - unless:
+                condition: << parameters.settings_file >>
+                steps:
+                  - run:
+                      name: Run Tests
+                      command: mvn << parameters.command >> -Dsurefire.excludesFile=.circleci/tests/surefire_classnames_ignore_list -Dfailsafe.excludesFile=.circleci/tests/failsafe_classnames_ignore_list
       - process_test_results:
           test_results_path: << parameters.test_results_path >>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ X ] All new jobs, commands, executors, parameters have descriptions
- [ X ] Examples have been added for any significant new features
- [ X ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
This change lets you use a custom maven settings file

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Add parameter 'settings_file' to command 'with_cache' and jobs 'test' and 'paralell_test'