### PR TITLE
fix aws-s3 line breaks

### DIFF
--- a/src/aws-s3/orb.yml
+++ b/src/aws-s3/orb.yml
@@ -97,8 +97,11 @@ commands:
           aws-region: << parameters.aws-region >>
       - deploy:
           name: Deploy to S3
-          command: "aws s3 sync << parameters.from >> << parameters.to >><<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >><<# parameters.overwrite >> --delete<</ parameters.overwrite >>"
-
+          command: |
+            aws s3 sync \
+              <<parameters.from>> <<parameters.to>> \
+              <<#parameters.arguments>><<parameters.arguments>><</parameters.arguments>><<#parameters.overwrite>> \
+              --delete<</parameters.overwrite>>
 
   copy:
     description: "Copies a local file or S3 object to another location locally or in S3. https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html"


### PR DESCRIPTION
fix some linebreaks / quotations

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

https://github.com/CircleCI-Public/circleci-orbs/issues/147

### Description

people are passing multi-line values to the `arguments` parameter, but in the orb source, everything is on a single line; this is causing shell issues due to missing `\` characters
