### PR TITLE
Fix cache miss due to find behaviour

### DIFF
--- a/src/maven/orb.yml
+++ b/src/maven/orb.yml
@@ -121,7 +121,7 @@ commands:
     steps:
       - run:
           name: Generate Cache Checksum
-          command: find . -name 'pom.xml' -exec cat {} + | shasum | awk '{print $1}' > /tmp/maven_cache_seed
+          command: find . -name 'pom.xml' | sort | xargs cat > /tmp/maven_cache_seed
       - restore_cache:
           key: maven-{{ checksum "/tmp/maven_cache_seed" }}
       - when:


### PR DESCRIPTION
* Find directory traversing is unpredictable across different builds: https://serverfault.com/a/181815/72778
* Using sort to make find output predictable
* Removed shasum since unnecessary, the file is used in restore_cache always with `checksum` construct.
