### PR TITLE
Updated gradle cache key generation to find 'build.gradle' or 'build.gradle.kts'

### DIFF
--- a/src/gradle/orb.yml
+++ b/src/gradle/orb.yml
@@ -83,15 +83,15 @@ commands:
       The contents of the `~/.gradle` directory is cached, which will substantially
       improve build times for projects with many dependencies.
 
-      The cache-key is generated from any files named `build.gradle` that are
-      present in the `working_directory`.
+      The cache-key is generated from any files named `build.gradle` or
+      `build.gradle.kts` that are present in the `working_directory`.
     parameters:
       steps:
         type: steps
     steps:
       - run:
           name: Generate Cache Checksum
-          command: find . -name 'build.gradle' | sort | xargs cat | shasum | awk '{print $1}' > /tmp/gradle_cache_seed
+          command: find . -name 'build.gradle' -or -name 'build.gradle.kts' | sort | xargs cat | shasum | awk '{print $1}' > /tmp/gradle_cache_seed
       - restore_cache:
           key: gradle-{{ checksum "/tmp/gradle_cache_seed" }}-{{ checksum ".circleci/config.yml" }}
       - steps: << parameters.steps >>


### PR DESCRIPTION


### Checklist

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

I've file the issue about his [here](https://github.com/CircleCI-Public/circleci-orbs/issues/180). To reiterate, if [Gradle Kotlin DSL](https://docs.gradle.org/current/userguide/kotlin_dsl.html) is used, `with_cache` will not be able to generate the key, since gradle file will be named `build.gradle.kts`. This file name should be used as an alternative to `build.gradle` without additional configuration because Kotlin DSL is an official part of Gradle. As it stands, caching with Gradle Kotlin DSL is not supported even at the basic level and the orb cannot be used. I feel this use case is different than [this enhancement](https://github.com/CircleCI-Public/circleci-orbs/issues/132) as having a file named `build.gradle.kts` is the standard and only way of using Kotlin DSL in Gradle.

### Description

The `find` command has been extended to search for files named `build.gradle` or `build.gradle.kts`. The pertinent doc comment has been updated.