### PR TITLE
Default maven settings file to pom.xml

### DIFF
--- a/src/maven/orb.yml
+++ b/src/maven/orb.yml
@@ -116,6 +116,7 @@ commands:
       settings_file:
         description: Specify a custom settings file to use (optional)
         type: string
+        default: pom.xml
       steps:
         type: steps
       maven_command:
@@ -180,6 +181,7 @@ jobs:
       settings_file:
         description: Specify a custom settings file to use (optional)
         type: string
+        default: pom.xml
       maven_command:
         description: Specify a custom path for invoking maven
         type: string
@@ -223,6 +225,7 @@ jobs:
       settings_file:
         description: Specify a custom settings file to use (optional)
         type: string
+        default: pom.xml
       maven_command:
         description: Specify a custom path for invoking maven
         type: string


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues
The documentation for the maven orb suggests that the `settings_file` parameter is optional, but it has no default value set. This was likely an oversight when the `settings_file` was added. This causes the examples to be incorrect and the standard maven archetypes to require additional configuration.
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
Default the `settings_file` parameter to `pom.xml`
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
