### PR TITLE
Fix 'maven_command' parameter parsing from test job to 'with_cache' c…

### DIFF
--- a/src/maven/orb.yml
+++ b/src/maven/orb.yml
@@ -189,6 +189,7 @@ jobs:
       - checkout
       - with_cache:
           settings_file: << parameters.settings_file >>
+          maven_command: << parameters.maven_command >>
           steps:
             - when:
                 condition: << parameters.settings_file >>

--- a/src/maven/orb.yml
+++ b/src/maven/orb.yml
@@ -290,6 +290,7 @@ jobs:
           path: .circleci/tests/
       - with_cache:
           settings_file: << parameters.settings_file >>
+          maven_command: << parameters.maven_command >>
           steps:
             - when:
                 condition: << parameters.settings_file >>


### PR DESCRIPTION
…ommand

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

When using pom.xml in the folder, different than the root you can define maven command like `mvn -f folder/pom.xml` but this doesn/t affect `dependency` command

### Description


