### PR TITLE
Make deploy-bundle succeed only if status is "Ready"

### DIFF
--- a/src/aws-code-deploy/orb.yml
+++ b/src/aws-code-deploy/orb.yml
@@ -200,7 +200,7 @@ commands:
                       --output text \
                       --query '[deploymentInfo.status]'<<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>)
 
-            while [[ $STATUS == "Created" || $STATUS == "InProgress" || $STATUS == "Pending" ]]; do
+            while [[ $STATUS == "Created" || $STATUS == "InProgress" || $STATUS == "Pending" || $STATUS == "Queued" ]]; do
               echo "Status: $STATUS..."
               STATUS=$(aws deploy get-deployment \
                         --deployment-id $ID \
@@ -209,14 +209,15 @@ commands:
               sleep 5
             done
 
-            if [[ $STATUS == "Failed" ]]; then
-              echo "Deployment failed!"
-              aws deploy get-deployment --deployment-id $ID<<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>
-              exit 1
-            else
+            if [[ $STATUS == "Ready" ]]; then
+              EXITCODE=0
               echo "Deployment finished."
-              aws deploy get-deployment --deployment-id $ID<<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>
+            else
+              EXITCODE=1
+              echo "Deployment failed!"
             fi
+            aws deploy get-deployment --deployment-id $ID<<# parameters.arguments >> << parameters.arguments >><</parameters.arguments >>
+            exit $EXITCODE
 
 jobs:
   deploy:


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
According to the [GetDeployment API docs](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_DeploymentInfo.html#CodeDeploy-Type-DeploymentInfo-status) the `status` field has 7 valid statuses, of which only `Ready` should count as a success.

Fixes #167.
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
1. Add the missing `Queued` status to the "wait" loop.
1. Make `Ready` the only successful status. Every other status (`Failed` / `Stopped`) will result in a failure.

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
