### PR TITLE
maven: add default for test_results_path parameter

### DIFF
--- a/src/maven/orb.yml
+++ b/src/maven/orb.yml
@@ -155,7 +155,9 @@ commands:
       You can override where to find the test results with the path parameter.
     parameters:
       test_results_path:
+        description: Specify a custom path for maven test results
         type: string
+        default: target/surefire-reports
     steps:
       - store_test_results:
           path: << parameters.test_results_path >>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
Fixes https://github.com/CircleCI-Public/circleci-orbs/issues/71

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Updates default value for `test_results_path` in `process_test_results` command to reflect the doc string. 
